### PR TITLE
feat: Add automatic docker images build/push to AWS/GCP

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -1,0 +1,84 @@
+name: Build and push images to Registries (AWS ECR and GCP Artifact Registry)
+
+on:
+  push:
+    branches: [ "develop", "main" ]
+
+jobs:
+  build-and-push-aws:
+    strategy:
+      matrix:
+        service: [ "authorizer", "sports", "users" ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Resolve Tag
+        id: resolve-tag
+        run: |
+          branch=""
+          if [ ${{ github.ref }} == 'refs/heads/main' ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=develop" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ matrix.service }}
+          IMAGE_TAG: ${{ steps.resolve-tag.outputs.tag }}
+        run: |
+          cd projects/$REPOSITORY
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+
+  build-and-push-gcp:
+    strategy:
+      matrix:
+        service: [ "alerts", "authorizer", "sports", "users" ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+
+      - name: Configure docker gcloud auth
+        run: gcloud auth configure-docker
+
+      - name: Resolve Tag
+        id: resolve-tag
+        run: |
+          branch=""
+          if [ ${{ github.ref }} == 'refs/heads/main' ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=develop" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build, tag, and push docker image to Google Artifact Registry
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_PROJECT_REGION: ${{ secrets.GCP_PROJECT_REGION }}
+          REPOSITORY: ${{ matrix.service }}
+          IMAGE_TAG: ${{ steps.resolve-tag.outputs.tag }}
+        run: |
+          cd projects/$REPOSITORY
+          docker build -t $GCP_PROJECT_REGION-docker.pkg.dev/$GCP_PROJECT_ID/sportapp/$REPOSITORY:$IMAGE_TAG .
+          docker push $GCP_PROJECT_REGION-docker.pkg.dev/$GCP_PROJECT_ID/sportapp/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -5,7 +5,17 @@ on:
     branches: [ "develop", "main" ]
 
 jobs:
+  resolve-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - id: tag
+        run: |
+          echo "tag=${{ github.ref_name == 'main' && 'latest' || 'develop' }}" >> $GITHUB_OUTPUT
+
   build-and-push-aws:
+    needs: resolve-tag
     strategy:
       matrix:
         service: [ "authorizer", "sports", "users" ]
@@ -28,18 +38,13 @@ jobs:
       - name: Resolve Tag
         id: resolve-tag
         run: |
-          branch=""
-          if [ ${{ github.ref }} == 'refs/heads/main' ]; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          else
-            echo "tag=develop" >> $GITHUB_OUTPUT
-          fi
+          echo "tag=${{ github.ref_name == 'main' && 'latest' || 'develop' }}" >> $GITHUB_OUTPUT
 
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ matrix.service }}
-          IMAGE_TAG: ${{ steps.resolve-tag.outputs.tag }}
+          IMAGE_TAG: ${{ needs.resolve-tag.outputs.image_tag }}
         run: |
           cd projects/$REPOSITORY
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
@@ -47,6 +52,7 @@ jobs:
 
 
   build-and-push-gcp:
+    needs: resolve-tag
     strategy:
       matrix:
         service: [ "alerts", "authorizer", "sports", "users" ]
@@ -65,19 +71,14 @@ jobs:
       - name: Resolve Tag
         id: resolve-tag
         run: |
-          branch=""
-          if [ ${{ github.ref }} == 'refs/heads/main' ]; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          else
-            echo "tag=develop" >> $GITHUB_OUTPUT
-          fi
+          echo "tag=${{ github.ref_name == 'main' && 'latest' || 'develop' }}" >> $GITHUB_OUTPUT
 
       - name: Build, tag, and push docker image to Google Artifact Registry
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           GCP_PROJECT_REGION: ${{ secrets.GCP_PROJECT_REGION }}
           REPOSITORY: ${{ matrix.service }}
-          IMAGE_TAG: ${{ steps.resolve-tag.outputs.tag }}
+          IMAGE_TAG: ${{ needs.resolve-tag.outputs.image_tag }}
         run: |
           cd projects/$REPOSITORY
           docker build -t $GCP_PROJECT_REGION-docker.pkg.dev/$GCP_PROJECT_ID/sportapp/$REPOSITORY:$IMAGE_TAG .


### PR DESCRIPTION
Este cambio introduce un nuevo workflow definido en el archivo .github/workflows/build-and-push-images.yml, el cual se encarga de construir y subir imágenes Docker a AWS ECR y GCP Artifact Registry. Este proceso se activa con los pushes en las ramas, gestionando de manera específica los servicios para cada uno de los registros y etiquetando las imágenes basándose en la rama antes de subirlas a sus respectivos registros.

