### PR TITLE
Feature: PSA-161 Add get user personal profile endpoint with tests

### DIFF
--- a/.github/workflows/sync-sonar-coverage.yml
+++ b/.github/workflows/sync-sonar-coverage.yml
@@ -1,4 +1,4 @@
-name: Check PRs on Users service
+name: Sync SonarCloud Coverage information
 
 on:
   push:

--- a/projects/users/app/models/mappers/user_mapper.py
+++ b/projects/users/app/models/mappers/user_mapper.py
@@ -2,8 +2,6 @@ import enum
 from dataclasses import asdict
 from uuid import UUID
 
-from app.models.schemas.profiles_schema import UserPersonalProfile
-
 
 class DataClassMapper:
     @staticmethod

--- a/projects/users/app/models/mappers/user_mapper.py
+++ b/projects/users/app/models/mappers/user_mapper.py
@@ -2,12 +2,12 @@ import enum
 from dataclasses import asdict
 from uuid import UUID
 
+from app.models.schemas.profiles_schema import UserPersonalProfile
+
 
 class DataClassMapper:
-    def __init__(self, data_class):
-        self.data_class = data_class
-
-    def to_dict(self, instance):
+    @staticmethod
+    def to_dict(instance):
         def custom_encoder(obj):
             if isinstance(obj, UUID):
                 return str(obj)
@@ -16,3 +16,8 @@ class DataClassMapper:
             return obj
 
         return {k: custom_encoder(v) for k, v in asdict(instance).items() if v is not None and k != "hashed_password"}
+
+    @staticmethod
+    def to_subclass_dict(user, subclass):
+        instance = subclass(*[getattr(user, field) for field in subclass.__dataclass_fields__])
+        return DataClassMapper.to_dict(instance)

--- a/projects/users/app/models/schemas/profiles_schema.py
+++ b/projects/users/app/models/schemas/profiles_schema.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from app.models.users import UserIdentificationType, Gender
+
+
+@dataclass
+class UserPersonalProfile:
+    email: str
+    first_name: str
+    last_name: str
+    identification_type: UserIdentificationType
+    identification_number: str
+    gender: Gender
+    country_of_birth: str
+    city_of_birth: str
+    country_of_residence: str
+    city_of_residence: str
+    residence_age: int
+    birth_date: str

--- a/projects/users/app/models/users.py
+++ b/projects/users/app/models/users.py
@@ -1,6 +1,5 @@
 import enum
 from dataclasses import dataclass
-from datetime import date
 from uuid import uuid4
 
 from sqlalchemy import Column, Uuid, Enum, String, Integer, Float

--- a/projects/users/app/routes/users_routes.py
+++ b/projects/users/app/routes/users_routes.py
@@ -62,3 +62,9 @@ async def login_user(user_credentials: UserCredentials, db: Session = Depends(ge
 async def complete_user_registration(user_id: uuid.UUID, user_additional_information: UserAdditionalInformation, db: Session = Depends(get_db)):
     complete_user_registration_response = UsersService(db).complete_user_registration(user_id, user_additional_information)
     return JSONResponse(content=complete_user_registration_response, status_code=200)
+
+
+@router.get("/profiles/{user_id}/personal")
+async def get_user_personal_information(user_id: uuid.UUID, db: Session = Depends(get_db)):
+    user_personal_information = UsersService(db).get_user_personal_information(user_id)
+    return JSONResponse(content=user_personal_information, status_code=200)

--- a/projects/users/tests/unit/models/schemas/profiles_schema_test.py
+++ b/projects/users/tests/unit/models/schemas/profiles_schema_test.py
@@ -2,10 +2,7 @@ import unittest
 from faker import Faker
 
 from app.models.schemas.profiles_schema import UserPersonalProfile
-from app.models.schemas.schema import UserCreate, UserCredentials, UserAdditionalInformation
 from app.models.users import UserIdentificationType, Gender
-
-from app.exceptions.exceptions import InvalidValueError
 
 fake = Faker()
 

--- a/projects/users/tests/unit/models/schemas/profiles_schema_test.py
+++ b/projects/users/tests/unit/models/schemas/profiles_schema_test.py
@@ -1,0 +1,42 @@
+import unittest
+from faker import Faker
+
+from app.models.schemas.profiles_schema import UserPersonalProfile
+from app.models.schemas.schema import UserCreate, UserCredentials, UserAdditionalInformation
+from app.models.users import UserIdentificationType, Gender
+
+from app.exceptions.exceptions import InvalidValueError
+
+fake = Faker()
+
+
+class TestUserProfiles(unittest.TestCase):
+    def test_user_personal_profile(self):
+        user_personal_profile_data = {
+            "email": fake.email(),
+            "first_name": fake.first_name(),
+            "last_name": fake.last_name(),
+            "identification_type": fake.enum(UserIdentificationType),
+            "identification_number": fake.numerify(text="############"),
+            "gender": fake.enum(Gender),
+            "country_of_birth": fake.country(),
+            "city_of_birth": fake.city(),
+            "country_of_residence": fake.country(),
+            "city_of_residence": fake.city(),
+            "residence_age": fake.random_int(min=1, max=100),
+            "birth_date": fake.date_of_birth(minimum_age=18).strftime("%Y-%m-%d"),
+        }
+
+        user_personal_profile = UserPersonalProfile(**user_personal_profile_data)
+        self.assertEqual(user_personal_profile.email, user_personal_profile_data["email"])
+        self.assertEqual(user_personal_profile.first_name, user_personal_profile_data["first_name"])
+        self.assertEqual(user_personal_profile.last_name, user_personal_profile_data["last_name"])
+        self.assertEqual(user_personal_profile.identification_type, user_personal_profile_data["identification_type"])
+        self.assertEqual(user_personal_profile.identification_number, user_personal_profile_data["identification_number"])
+        self.assertEqual(user_personal_profile.gender, user_personal_profile_data["gender"])
+        self.assertEqual(user_personal_profile.country_of_birth, user_personal_profile_data["country_of_birth"])
+        self.assertEqual(user_personal_profile.city_of_birth, user_personal_profile_data["city_of_birth"])
+        self.assertEqual(user_personal_profile.country_of_residence, user_personal_profile_data["country_of_residence"])
+        self.assertEqual(user_personal_profile.city_of_residence, user_personal_profile_data["city_of_residence"])
+        self.assertEqual(user_personal_profile.residence_age, user_personal_profile_data["residence_age"])
+        self.assertEqual(user_personal_profile.birth_date, user_personal_profile_data["birth_date"])

--- a/projects/users/tests/unit/routes/users_routes_test.py
+++ b/projects/users/tests/unit/routes/users_routes_test.py
@@ -192,3 +192,31 @@ class TestUsersRoutes(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         authenticate_user_mock.assert_called_once_with(user_credentials)
         self.assertEqual(response_body, token_data)
+
+    @patch("app.services.users.UsersService.get_user_personal_information")
+    async def test_get_user_personal_information(self, get_user_personal_information_mock):
+        user_id = fake.uuid4()
+        user_data = {
+            "email": fake.email(),
+            "first_name": fake.first_name(),
+            "last_name": fake.last_name(),
+            "identification_type": fake.enum(UserIdentificationType).value,
+            "identification_number": fake.numerify(text="############"),
+            "gender": fake.enum(Gender).value,
+            "country_of_birth": fake.country(),
+            "city_of_birth": fake.city(),
+            "country_of_residence": fake.country(),
+            "city_of_residence": fake.city(),
+            "residence_age": fake.random_int(min=1, max=100),
+            "birth_date": fake.date_of_birth(minimum_age=18).strftime("%Y-%m-%d"),
+        }
+
+        get_user_personal_information_mock.return_value = user_data
+
+        db = MagicMock()
+        response = await users_routes.get_user_personal_information(user_id, db)
+        response_body = json.loads(response.body)
+
+        self.assertEqual(response.status_code, 200)
+        get_user_personal_information_mock.assert_called_once_with(user_id)
+        self.assertEqual(response_body, user_data)

--- a/projects/users/tests/unit/services/users_test.py
+++ b/projects/users/tests/unit/services/users_test.py
@@ -6,13 +6,19 @@ from faker import Faker
 from jose import JWTError
 from sqlalchemy.orm import Session
 
-from app.models.schemas.schema import UserCredentials
+from app.models.schemas.profiles_schema import UserPersonalProfile
 from app.services.users import UsersService
 from app.exceptions.exceptions import NotFoundError, InvalidCredentialsError
 from app.models.users import User
-from app.models.mappers.mapper import DataClassMapper
+from app.models.mappers.user_mapper import DataClassMapper
 
-from tests.utils.users_util import generate_random_user_create_data, generate_random_user_additional_information, generate_random_user_login_data
+from tests.utils.users_util import (
+    generate_random_user_create_data,
+    generate_random_user_additional_information,
+    generate_random_user_login_data,
+    generate_random_user,
+    generate_random_user_personal_profile,
+)
 
 fake = Faker()
 
@@ -20,10 +26,8 @@ fake = Faker()
 class TestUsersService(unittest.TestCase):
     def setUp(self):
         self.mock_jwt = MagicMock()
-        self.mock_mapper = MagicMock(spec=DataClassMapper)
         self.mock_db = MagicMock(spec=Session)
         self.users_service = UsersService(db=self.mock_db)
-        self.users_service.mapper = self.mock_mapper
         self.users_service.jwt_manager = self.mock_jwt
 
     @patch("bcrypt.hashpw")
@@ -55,7 +59,8 @@ class TestUsersService(unittest.TestCase):
         self.assertEqual(execute_mock.fetchall.call_count, 1)
         self.assertEqual(self.mock_db.commit.call_count, 1)
 
-    def test_complete_user_registration(self):
+    @patch("app.models.mappers.user_mapper.DataClassMapper.to_dict")
+    def test_complete_user_registration(self, mock_to_dict):
         user_create_data = generate_random_user_create_data(fake)
         user_additional_info = generate_random_user_additional_information(fake)
         user_id = fake.uuid4()
@@ -76,16 +81,17 @@ class TestUsersService(unittest.TestCase):
         mock_query.filter.return_value = mock_filter
         mock_filter.first.return_value = mock_first
 
-        self.mock_mapper.to_dict.return_value = user.__dict__
+        mock_to_dict.to_dict.return_value = user.__dict__
         self.mock_db.commit.return_value = None
 
         self.users_service.complete_user_registration(user_id=user_id, user_additional_information=user_additional_info)
 
-        self.assertEqual(self.mock_mapper.to_dict.call_count, 1)
+        mock_to_dict.assert_called_once_with(mock_first)
         self.assertEqual(self.mock_db.query.call_count, 1)
         self.assertEqual(self.mock_db.commit.call_count, 1)
 
-    def test_complete_user_registration_non_existing_user(self):
+    @patch("app.models.mappers.user_mapper.DataClassMapper.to_dict")
+    def test_complete_user_registration_non_existing_user(self, mock_to_dict):
         user_create_data = generate_random_user_create_data(fake)
         user_additional_info = generate_random_user_additional_information(fake)
         user_id = fake.uuid4()
@@ -105,7 +111,7 @@ class TestUsersService(unittest.TestCase):
         mock_query.filter.return_value = mock_filter
         mock_filter.first.return_value = None
 
-        self.mock_mapper.to_dict.return_value = user.__dict__
+        mock_to_dict.to_dict.return_value = user.__dict__
         self.mock_db.commit.return_value = None
 
         with self.assertRaises(NotFoundError) as context:
@@ -192,3 +198,26 @@ class TestUsersService(unittest.TestCase):
         with self.assertRaises(InvalidCredentialsError) as context:
             self.users_service.authenticate_user(user_credentials)
         self.assertEqual(str(context.exception), "Invalid or expired refresh token")
+
+    @patch("app.models.mappers.user_mapper.DataClassMapper.to_subclass_dict")
+    def test_get_user_personal_profile(self, mock_to_subclass_dict):
+        user_id = fake.uuid4()
+        user = generate_random_user(fake)
+        user_personal_profile = generate_random_user_personal_profile(fake)
+        self.mock_db.query.return_value.filter.return_value.first.return_value = user
+        mock_to_subclass_dict.return_value = user_personal_profile
+
+        response = self.users_service.get_user_personal_information(user_id)
+
+        self.assertEqual(response, user_personal_profile)
+        mock_to_subclass_dict.assert_called_once_with(user, UserPersonalProfile)
+        self.mock_db.query.assert_called_once_with(User)
+        self.mock_db.query.return_value.filter.assert_called_once()
+
+    def test_get_user_personal_profile_user_not_found(self):
+        user_id = fake.uuid4()
+        self.mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        with self.assertRaises(NotFoundError) as context:
+            self.users_service.get_user_personal_information(user_id)
+        self.assertEqual(str(context.exception), f"User with id {user_id} not found")

--- a/projects/users/tests/unit/services/users_test.py
+++ b/projects/users/tests/unit/services/users_test.py
@@ -10,7 +10,6 @@ from app.models.schemas.profiles_schema import UserPersonalProfile
 from app.services.users import UsersService
 from app.exceptions.exceptions import NotFoundError, InvalidCredentialsError
 from app.models.users import User
-from app.models.mappers.user_mapper import DataClassMapper
 
 from tests.utils.users_util import (
     generate_random_user_create_data,

--- a/projects/users/tests/utils/users_util.py
+++ b/projects/users/tests/utils/users_util.py
@@ -1,3 +1,4 @@
+from app.models.schemas.profiles_schema import UserPersonalProfile
 from app.models.users import User, UserIdentificationType, FoodPreference, Gender, UserSubscriptionType
 from app.models.schemas.schema import UserCreate, UserAdditionalInformation, UserCredentials
 
@@ -39,27 +40,44 @@ def generate_random_user_create_data(faker):
     return UserCreate(first_name=faker.first_name(), last_name=faker.last_name(), email=faker.email(), password=f"{faker.password()}A123!")
 
 
+def generate_random_user_personal_profile(faker):
+    user = generate_random_user(faker)
+    return UserPersonalProfile(
+        email=user.email,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        identification_type=UserIdentificationType(user.identification_type),
+        identification_number=user.identification_number,
+        gender=Gender(user.gender),
+        country_of_birth=user.country_of_birth,
+        city_of_birth=user.city_of_birth,
+        country_of_residence=user.country_of_residence,
+        city_of_residence=user.city_of_residence,
+        residence_age=user.residence_age,
+        birth_date=user.birth_date,
+    )
+
+
 def generate_random_user(faker):
     return User(
-        user_id=faker.fake.uuid4(),
-        first_name=faker.fake.first_name(),
-        last_name=faker.fake.last_name(),
-        email=faker.fake.email(),
-        hashed_password=faker.fake.password(),
-        identification_type=faker.fake.random_element(elements=UserIdentificationType),
-        identification_number=faker.fake.random_number(),
-        gender=faker.fake.random_element(elements=Gender),
-        country_of_birth=faker.fake.country(),
-        city_of_birth=faker.fake.city(),
-        country_of_residence=faker.fake.country(),
-        city_of_residence=faker.fake.city(),
-        residence_age=faker.fake.random_number(),
-        birth_date=faker.fake.date_of_birth(minimum_age=15).isoformat(),
-        weight=faker.fake.pyfloat(left_digits=2, right_digits=2, positive=True),
-        height=faker.fake.pyfloat(left_digits=3, right_digits=2, positive=True),
-        training_years=faker.fake.random_number(),
-        training_hours_per_week=faker.fake.random_number(),
-        available_training_hours_per_week=faker.fake.random_number(),
-        food_preference=faker.fake.random_element(elements=FoodPreference),
-        subscription_type=faker.fake.random_element(elements=UserSubscriptionType),
+        first_name=faker.first_name(),
+        last_name=faker.last_name(),
+        email=faker.email(),
+        hashed_password=faker.password(),
+        identification_type=faker.enum(UserIdentificationType),
+        identification_number=faker.random_number(),
+        gender=faker.enum(Gender),
+        country_of_birth=faker.country(),
+        city_of_birth=faker.city(),
+        country_of_residence=faker.country(),
+        city_of_residence=faker.city(),
+        residence_age=faker.random_number(),
+        birth_date=faker.date_of_birth(minimum_age=15).isoformat(),
+        weight=faker.pyfloat(left_digits=2, right_digits=2, positive=True),
+        height=faker.pyfloat(left_digits=3, right_digits=2, positive=True),
+        training_years=faker.random_number(),
+        training_hours_per_week=faker.random_number(),
+        available_training_hours_per_week=faker.random_number(),
+        food_preference=faker.random_element(elements=FoodPreference),
+        subscription_type=faker.random_element(elements=UserSubscriptionType),
     )


### PR DESCRIPTION
[PSA-161](https://misoteam-proyecto.atlassian.net/browse/PSA-161)

## Resumen de cambios

Se ha realizado una serie de actualizaciones en el proyecto de usuarios, centradas en mejorar la gestión de la información personal del usuario. Esto incluye la introducción de un nuevo método estático para convertir objetos de usuario en subclases específicas, la definición de una nueva clase de datos para perfiles personales, la eliminación de importaciones no utilizadas, la adición de una nueva ruta para recuperar información personal del usuario, y actualizaciones en el servicio de usuarios para utilizar el nuevo mapeador de clases de datos. Además, se han añadido pruebas para validar la nueva funcionalidad.

[PSA-161]: https://misoteam-proyecto.atlassian.net/browse/PSA-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ