### PR TITLE
Fix: Update sync-sonar-coverage workflow

### DIFF
--- a/.github/workflows/sync-sonar-coverage.yml
+++ b/.github/workflows/sync-sonar-coverage.yml
@@ -21,12 +21,13 @@ jobs:
         run: |
           echo "branch=$REF_NAME" >> $GITHUB_OUTPUT
 
-  update-sonarcloud-coverage-report:
+
+  update-python-projects-sonarcloud-coverage-report:
     needs: get-branch
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [ "authorizer", "sports", "sport-sessions", "users", "business-partners", "miso-stripe" ]
+        service: [ "authorizer", "sports", "sport-sessions", "users", "business-partners" ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,6 +60,54 @@ jobs:
           SERVICE: ${{ matrix.service }}
         run: |
           sed -i 's/\/home\/runner\/work\/sportapp-back\/sportapp-back\//\/github\/workspace\//g' projects/$SERVICE/coverage.xml
+
+      - name: Add branch name to properties file
+        env:
+          SERVICE: ${{ matrix.service }}
+          BRANCH: ${{ needs.get-branch.outputs.branch }}
+        run: |
+          echo "sonar.branch.name=$BRANCH" >> projects/$SERVICE/sonar-project.properties
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          projectBaseDir: projects/${{ matrix.service }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  update-js-projects-sonarcloud-coverage-report:
+    needs: get-branch
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [ "miso-stripe" ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Yarn
+        run: |
+          npm i -g yarn
+
+      - name: Install dependencies
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: |
+          cd projects/$SERVICE
+          yarn install --frozen-lockfile
+
+      - name: Run Unit tests and coverage
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: |
+          cd projects/$SERVICE
+          yarn test:unit
 
       - name: Add branch name to properties file
         env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renombrado el trabajo de actualización de informes de cobertura en Sonarcloud para proyectos de Python.
	- Eliminado el servicio "miso-stripe" del trabajo de actualización para proyectos de Python en Sonarcloud.
	- Añadido un nuevo trabajo de actualización de cobertura para proyectos Node.js en Sonarcloud específicamente para el servicio "miso-stripe".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->