### PR TITLE
Refactor: Add test notification for alerts service

### DIFF
--- a/infra/terraform/aws/dev/services/alerts/main.tf
+++ b/infra/terraform/aws/dev/services/alerts/main.tf
@@ -131,3 +131,12 @@ module "alerts-get-device-route" {
   elb_listener_arn = data.terraform_remote_state.resources.outputs.elb_listener_arn
   vpc_link_id      = data.terraform_remote_state.resources.outputs.vpc_link_id
 }
+
+module "alerts-send-test-alert-route" {
+  source           = "../../../modules/api_gateway/route"
+  api_id           = data.terraform_remote_state.resources.outputs.api_gateway_id
+  route_method     = "POST"
+  route_path       = "/alerts/send-test-alert"
+  elb_listener_arn = data.terraform_remote_state.resources.outputs.elb_listener_arn
+  vpc_link_id      = data.terraform_remote_state.resources.outputs.vpc_link_id
+}

--- a/infra/terraform/aws/prod/services/alerts/main.tf
+++ b/infra/terraform/aws/prod/services/alerts/main.tf
@@ -131,3 +131,12 @@ module "alerts-get-device-route" {
   elb_listener_arn = data.terraform_remote_state.resources.outputs.elb_listener_arn
   vpc_link_id      = data.terraform_remote_state.resources.outputs.vpc_link_id
 }
+
+module "alerts-send-test-alert-route" {
+  source           = "../../../modules/api_gateway/route"
+  api_id           = data.terraform_remote_state.resources.outputs.api_gateway_id
+  route_method     = "POST"
+  route_path       = "/alerts/send-test-alert"
+  elb_listener_arn = data.terraform_remote_state.resources.outputs.elb_listener_arn
+  vpc_link_id      = data.terraform_remote_state.resources.outputs.vpc_link_id
+}

--- a/infra/terraform/aws/qa/services/alerts/main.tf
+++ b/infra/terraform/aws/qa/services/alerts/main.tf
@@ -131,3 +131,12 @@ module "alerts-get-device-route" {
   elb_listener_arn = data.terraform_remote_state.resources.outputs.elb_listener_arn
   vpc_link_id      = data.terraform_remote_state.resources.outputs.vpc_link_id
 }
+
+module "alerts-send-test-alert-route" {
+  source           = "../../../modules/api_gateway/route"
+  api_id           = data.terraform_remote_state.resources.outputs.api_gateway_id
+  route_method     = "POST"
+  route_path       = "/alerts/send-test-alert"
+  elb_listener_arn = data.terraform_remote_state.resources.outputs.elb_listener_arn
+  vpc_link_id      = data.terraform_remote_state.resources.outputs.vpc_link_id
+}

--- a/projects/alerts/app/firebase/firebase.py
+++ b/projects/alerts/app/firebase/firebase.py
@@ -3,9 +3,8 @@ from firebase_admin import messaging
 
 def _build_message(device_registration_token: str, priority: str, title: str, message: str):
     notification = messaging.Notification(title=title, body=message)
-    android_config = messaging.AndroidConfig(priority=priority)
-
-    return messaging.Message(notification=notification, token=device_registration_token, android=android_config)
+    priority = {"priority": priority}
+    return messaging.Message(notification=notification, token=device_registration_token, data=priority)
 
 
 class FirebaseClient:

--- a/projects/alerts/app/models/schemas/schema.py
+++ b/projects/alerts/app/models/schemas/schema.py
@@ -6,3 +6,10 @@ from pydantic import BaseModel
 class UserAlertDeviceCreate(BaseModel):
     device_token: str
     enabled: Optional[bool] = True
+
+
+class TestAlert(BaseModel):
+    device_token: str
+    title: str
+    message: str
+    priority: str

--- a/projects/alerts/app/routes/alerts_routes.py
+++ b/projects/alerts/app/routes/alerts_routes.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from fastapi.responses import JSONResponse
 
 from app.config.db import get_db
-from app.models.schemas.schema import UserAlertDeviceCreate
+from app.models.schemas.schema import UserAlertDeviceCreate, TestAlert
 from app.services.alerts import AlertsService
 
 router = APIRouter(
@@ -33,3 +33,9 @@ async def disable_device(user_id: Annotated[UUID, Header()], db: Session = Depen
 async def get_user_device(user_id: Annotated[UUID, Header()], db: Session = Depends(get_db)):
     get_device_response = AlertsService(db).get_user_device(user_id)
     return JSONResponse(content=get_device_response, status_code=HTTPStatus.OK)
+
+
+@router.post("/send-test-alert")
+async def send_test_alert(user_id: Annotated[UUID, Header()], message_data: TestAlert, db: Session = Depends(get_db)):
+    test_alert_response = AlertsService(db).send_test_alert(message_data)
+    return JSONResponse(content=test_alert_response, status_code=HTTPStatus.OK)

--- a/projects/alerts/app/services/alerts.py
+++ b/projects/alerts/app/services/alerts.py
@@ -4,9 +4,10 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.exceptions.exceptions import NotFoundError
+from app.firebase.firebase import FirebaseClient
 from app.models.mappers.data_mapper import DataClassMapper
 from app.models.model import UserAlertDevice
-from app.models.schemas.schema import UserAlertDeviceCreate
+from app.models.schemas.schema import UserAlertDeviceCreate, TestAlert
 
 
 class AlertsService:
@@ -40,3 +41,8 @@ class AlertsService:
         self.db.commit()
 
         return DataClassMapper.to_dict(device)
+
+    def send_test_alert(self, alert_data: TestAlert):
+        FirebaseClient.send_fcm_alert(alert_data.device_token, alert_data.priority, alert_data.title, alert_data.message)
+
+        return {"message": "Test alert sent", "alert": alert_data.dict()}

--- a/projects/alerts/app/tasks/prioritizer.py
+++ b/projects/alerts/app/tasks/prioritizer.py
@@ -15,8 +15,8 @@ class QueueProcessor:
 
     def process_queues(self):
         while not self.stop_thread:
-            self.process_queue(self.nutritional_plan_queue_name, "Nutritional Plan", "normal")
-            self.process_queue(self.adverse_incidents_queue_name, "Adverse Incident", "high")
+            self.process_queue(self.nutritional_plan_queue_name, "Nutritional Plan", "info")
+            self.process_queue(self.adverse_incidents_queue_name, "Adverse Incident", "warning")
             sleep(0.5)
 
     def process_queue(self, queue_name: str, alert_type: str, alert_priority: str):

--- a/projects/alerts/tests/unit/routes/alerts_routes_test.py
+++ b/projects/alerts/tests/unit/routes/alerts_routes_test.py
@@ -49,3 +49,16 @@ class TestAlertsRoutes(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response_body["user_id"], str(device.user_id))
         self.assertEqual(response_body["device_token"], device.device_token)
         self.assertTrue(response_body["enabled"])
+
+    @patch("app.services.alerts.AlertsService.send_test_alert")
+    async def test_send_test_alert(self, mock_send_test_alert):
+        alert = {"device_token": fake.uuid4(), "priority": "high", "title": fake.sentence(), "message": fake.sentence()}
+
+        mock_return = {"message": "Test alert sent", "alert": alert}
+        mock_send_test_alert.return_value = mock_return
+        response = await alerts_routes.send_test_alert(fake.uuid4(), message_data=alert, db=fake.pystr())
+        response_body = json.loads(response.body)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["alert"], alert)
+        self.assertEqual(response_body["message"], "Test alert sent")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new API Gateway route for sending test alerts across development, production, and QA environments.
	- Added a new class `TestAlert` and endpoint to facilitate sending test alerts in the alerts application.
	- Implemented a new method in the `AlertsService` to send test alerts using Firebase.

- **Enhancements**
	- Modified the Firebase message building process to handle priority settings more effectively.

- **Refactor**
	- Updated the `Prioritizer` method to process queues based on "info" and "warning" alert priorities instead of "normal" and "high".

- **Tests**
	- Added new unit tests to validate the functionality of sending test alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->