### PR TITLE
Fix: Fix error with name too long for target group

### DIFF
--- a/infra/terraform/aws/dev/services/adverse-incidents-provider/main.tf
+++ b/infra/terraform/aws/dev/services/adverse-incidents-provider/main.tf
@@ -28,7 +28,7 @@ data "terraform_remote_state" "resources" {
 // Register target group and listener rule
 module "adverse-incidents-provider-tg" {
   source                         = "../../../modules/elb/target_group"
-  target_group_name              = "adverse-incidents-provider-dev-tg"
+  target_group_name              = "incidents-provider-dev-tg"
   target_group_port              = 8000
   target_group_protocol          = "HTTP"
   target_group_health_check_path = "/ping"

--- a/infra/terraform/aws/prod/services/adverse-incidents-provider/main.tf
+++ b/infra/terraform/aws/prod/services/adverse-incidents-provider/main.tf
@@ -28,7 +28,7 @@ data "terraform_remote_state" "resources" {
 // Register target group and listener rule
 module "adverse-incidents-provider-tg" {
   source                         = "../../../modules/elb/target_group"
-  target_group_name              = "adverse-incidents-provider-tg"
+  target_group_name              = "incidents-provider-tg"
   target_group_port              = 8000
   target_group_protocol          = "HTTP"
   target_group_health_check_path = "/ping"

--- a/infra/terraform/aws/qa/services/adverse-incidents-provider/main.tf
+++ b/infra/terraform/aws/qa/services/adverse-incidents-provider/main.tf
@@ -28,7 +28,7 @@ data "terraform_remote_state" "resources" {
 // Register target group and listener rule
 module "adverse-incidents-provider-tg" {
   source                         = "../../../modules/elb/target_group"
-  target_group_name              = "adverse-incidents-provider-qa-tg"
+  target_group_name              = "incidents-provider-qa-tg"
   target_group_port              = 8000
   target_group_protocol          = "HTTP"
   target_group_health_check_path = "/ping"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated target group names in AWS infrastructure configurations across development, production, and QA environments to enhance consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->